### PR TITLE
Add numberOfLines config option for Button.tsx

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -147,6 +147,10 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * Number of lines the label text is limited to. Defaults to 1
+   */
+  numberOfLines?: number;
 };
 
 /**
@@ -196,6 +200,7 @@ const Button = (
     background,
     maxFontSizeMultiplier,
     touchableRef,
+    numberOfLines = 1,
     ...rest
   }: Props,
   ref: React.ForwardedRef<View>
@@ -383,7 +388,7 @@ const Button = (
           <Text
             variant="labelLarge"
             selectable={false}
-            numberOfLines={1}
+            numberOfLines={numberOfLines}
             testID={`${testID}-text`}
             style={[
               styles.label,


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

https://github.com/callstack/react-native-paper/discussions/2584#discussioncomment-10715321

### Test plan

<img width="154" alt="image" src="https://github.com/user-attachments/assets/ddd59316-bbb8-4967-9d2e-8941a1d32d7d">

	<Button
		disabled={!touchedFields.location && !isDirty}
		icon="content-save-edit"
		onLongPress={handleSubmit(submit)}
		onPress={() => Alert.alert('Press & hold')}
		numberOfLines={1}
	>
		A short label
		{'\n'}
		<Text style={{ fontSize: 8, margin: 0, lineHeight: 12 }}>(Press & hold)</Text>
	</Button>


<img width="170" alt="image" src="https://github.com/user-attachments/assets/c7bee304-6179-4f13-bdba-e44bec1a7db7">

	<Button
		disabled={!touchedFields.location && !isDirty}
		icon="content-save-edit"
		onLongPress={handleSubmit(submit)}
		onPress={() => Alert.alert('Press & hold')}
		numberOfLines={2}
	>
		A short label
		{'\n'}
		<Text style={{ fontSize: 8, margin: 0, lineHeight: 12 }}>(Press & hold)</Text>
	</Button>

